### PR TITLE
feat!: Add SIGSCI_BUILDPACK prefix to environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ agent inside Heroku.
 
 ## Why?
 
-The [official Signal Sciences buildpack](https://docs.fastly.com/en/ngwaf/heroku) is unmaintained,
-has no license, and does things we don't necessarily want (or need). This is thermondo's
-implementation based on our [sigsci-container project](https://github.com/thermondo/sigsci-container).
+The [official Signal Sciences buildpack](https://docs.fastly.com/en/ngwaf/heroku) has no license
+and does things we don't necessarily want (or need). This is thermondo's implementation based on
+our [sigsci-container project](https://github.com/thermondo/sigsci-container).
 
 ## Quick Start
 
@@ -30,9 +30,30 @@ Then in your app's [Procfile](https://devcenter.heroku.com/articles/procfile) ad
 web: sigsci-wrap <the command you want to execute>
 ```
 
-The buildpack is configured the same way the container is (same environment variables, etc.). See
-the [Configuration section of the container README](https://github.com/thermondo/sigsci-container?tab=readme-ov-file#configuration)
-for details.
+## Configuration
+
+Required environment variables:
+
+* `SIGSCI_BUILDPACK_ACCESSKEYID`: SigSci access key ID. `SIGSCI_ACCESSKEYID` is also supported.
+* `SIGSCI_BUILDPACK_SECRETACCESSKEY`: SigSci access key secret. `SIGSCI_SECRETACCESSKEY` is also
+  supported.
+
+Optional environment variables:
+
+* `SIGSCI_BUILDPACK_UPSTREAM_PORT`: The port your app is listening on. It defaults to `2000` if not
+  specified, and re-exports this environment variable so your app can use it even if you don't
+  specify it. **Make sure it never conflicts with the `PORT` environment variable!** The default
+  value is a safe value.
+* `SIGSCI_BUILDPACK_WAIT_ENDPOINT`: An HTTP endpoint on your app that will be used to determine if
+  your app is up and running. When your app starts responding at this endpoint, the SigSci agent
+  will begin starting up. Example: Setting the value to `version` will cause the SigSci agent to
+  wait for `http://127.0.0.1:${SIGSCI_BUILDPACK_UPSTREAM_PORT}/version` to respond.
+* `SIGSCI_BUILDPACK_WAIT_TIMEOUT`: How long to wait, in seconds, for your app to respond. Defaults
+  to 60 seconds.
+* `SIGSCI_BUILDPACK_STATUS`: Set to `disabled` to temporarily disable the SigSci agent. This will
+  also cause the `SIGSCI_BUILDPACK_UPSTREAM_PORT` environment variable to be set to the same value
+  as `PORT` before starting your application, causing your application to receive requests directly
+  from the downstream router.
 
 ## Developing
 

--- a/bin/sigsci-wrap
+++ b/bin/sigsci-wrap
@@ -6,10 +6,10 @@
 # this script performs the following steps:
 #
 # 1. run the given command as a background job
-# 2. wait for an HTTP response at `SIGSCI_WAIT_ENDPOINT`
-# 3. run the sigsci agent, forwarding requests from `PORT` to `APP_PORT`
+# 2. wait for an HTTP response at `SIGSCI_BUILDPACK_WAIT_ENDPOINT`
+# 3. run the sigsci agent, forwarding requests from `PORT` to `SIGSCI_BUILDPACK_UPSTREAM_PORT`
 #
-# however if the `SIGSCI_STATUS` environment variable is set to `disabled`
+# however if the `SIGSCI_BUILDPACK_STATUS` environment variable is set to `disabled`
 # then this script will just execute step 1 only.
 #
 # SIGINT, SIGTERM signals that this process receives will be forwarded to
@@ -28,12 +28,12 @@ if [ "${#}" -eq 0 ]; then
 fi
 
 # check if sigsci is disabled. if so, just execute the command and be done with it!
-SIGSCI_STATUS="${SIGSCI_STATUS:-enabled}"
-if [ "${SIGSCI_STATUS}" == "disabled" ]; then
+SIGSCI_BUILDPACK_STATUS="${SIGSCI_BUILDPACK_STATUS:-enabled}"
+if [ "${SIGSCI_BUILDPACK_STATUS}" == "disabled" ]; then
     if [ "${PORT:-}" != "" ]; then
         # we still expect our container to listen on ${PORT}, but since we're not running the
         # sigsci agent, we need to tell the upstream app to run on that port instead.
-        export APP_PORT="${PORT}"
+        export SIGSCI_BUILDPACK_UPSTREAM_PORT="${PORT}"
     fi
 
     # `exec` replaces this shell with the given command. this makes it so we don't need to
@@ -43,11 +43,11 @@ if [ "${SIGSCI_STATUS}" == "disabled" ]; then
     exit ${?}
 fi
 
-export APP_PORT="${APP_PORT:-2000}"
+export SIGSCI_BUILDPACK_UPSTREAM_PORT="${SIGSCI_BUILDPACK_UPSTREAM_PORT:-2000}"
 
-if [ "${APP_PORT}" -eq "${PORT}" ]; then
+if [ "${SIGSCI_BUILDPACK_UPSTREAM_PORT}" -eq "${PORT}" ]; then
     log "FATAL: PORT env variable is set to ${PORT}, which is reserved for the upstream application."
-    log "Consider changing APP_PORT env variable to something that won't conflict."
+    log "Consider changing SIGSCI_BUILDPACK_UPSTREAM_PORT env variable to something that won't conflict."
     exit 1
 fi
 
@@ -61,13 +61,22 @@ fi
 # so the default /etc/sigsci/agent.conf location won't work.
 CONFIG_FILE="$(mktemp)"
 
+# don't require `SIGSCI_BUILDPACK` prefix for ACCESSKEYID and SECRETACCESSKEY
+# those are two common env variables we want to support
+if [ "${SIGSCI_ACCESSKEYID:-}" != "" ]; then
+    SIGSCI_BUILDPACK_ACCESSKEYID="${SIGSCI_ACCESSKEYID}"
+fi
+if [ "${SIGSCI_SECRETACCESSKEY:-}" != "" ]; then
+    SIGSCI_BUILDPACK_SECRETACCESSKEY="${SIGSCI_SECRETACCESSKEY}"
+fi
+
 echo "
-accesskeyid = \"${SIGSCI_ACCESSKEYID}\"
-secretaccesskey = \"${SIGSCI_SECRETACCESSKEY}\"
+accesskeyid = \"${SIGSCI_BUILDPACK_ACCESSKEYID}\"
+secretaccesskey = \"${SIGSCI_BUILDPACK_SECRETACCESSKEY}\"
 
 [revproxy-listener.APP]
 listener = \"http://0.0.0.0:${PORT}\"
-upstreams = \"http://127.0.0.1:${APP_PORT}\"
+upstreams = \"http://127.0.0.1:${SIGSCI_BUILDPACK_UPSTREAM_PORT}\"
 " > "${CONFIG_FILE}"
 
 # start child process in the background, save its PID so we can forward
@@ -88,7 +97,7 @@ trap 'on_signal_received SIGINT' SIGINT
 
 # now that the child process is running, let's spam it with HTTP requests
 # until we get a response
-UPSTREAM_URL="http://127.0.0.1:${APP_PORT}/${SIGSCI_WAIT_ENDPOINT:-}"
+UPSTREAM_URL="http://127.0.0.1:${SIGSCI_BUILDPACK_UPSTREAM_PORT}/${SIGSCI_BUILDPACK_WAIT_ENDPOINT:-}"
 log "waiting for ${UPSTREAM_URL} to respond..."
 
 send_upstream_request() {
@@ -98,7 +107,7 @@ send_upstream_request() {
 }
 
 wait_for_response() {
-    local timeout="${SIGSCI_WAIT_TIMEOUT:-60}"
+    local timeout="${SIGSCI_BUILDPACK_WAIT_TIMEOUT:-60}"
     local timeout_end=$(($(date +%s) + timeout))
 
     while ! send_upstream_request; do

--- a/bin/sigsci-wrap
+++ b/bin/sigsci-wrap
@@ -43,7 +43,7 @@ if [ "${SIGSCI_STATUS}" == "disabled" ]; then
     exit ${?}
 fi
 
-APP_PORT="${APP_PORT:-2000}"
+export APP_PORT="${APP_PORT:-2000}"
 
 if [ "${APP_PORT}" -eq "${PORT}" ]; then
     log "FATAL: PORT env variable is set to ${PORT}, which is reserved for the upstream application."


### PR DESCRIPTION
Does two things:

* renames environment variables to have `SIGSCI_BUILDPACK` prefix
* makes it so you don't need to configure or hard-code upstream port numbers

Example: If you have an NGINX ERB config, you can put this in it:

```erb
listen <%= ENV["SIGSCI_BUILDPACK_UPSTREAM_PORT"] %>;
```

This will allow the buildpack to choose what port your NGINX server listens on, so you never need
to configure it yourself.
